### PR TITLE
Added support for verify_ssl_cert in *Client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ notebooks/local-mode/experiments/
 notebooks/**/*.md
 **/.ipynb_checkpoints/
 *BranchRevision.json
+venv/

--- a/cortex/auth.py
+++ b/cortex/auth.py
@@ -16,14 +16,14 @@ limitations under the License.
 
 import json
 
-from .serviceconnector import ServiceConnector
+from .serviceconnector import _Client
 from .utils import get_logger
 from .utils import raise_for_status_with_detail
 
 log = get_logger(__name__)
 
 
-class AuthenticationClient:
+class AuthenticationClient(_Client):
     """
     Client authentication.
     """
@@ -32,9 +32,6 @@ class AuthenticationClient:
             'register':     'admin/tenants/register',
             'upgrade':      'accounts/token/upgrade'
            }
-
-    def __init__(self, url, version):
-        self._serviceconnector = ServiceConnector(url, version, None)
 
     def fetch_auth_token(self, tenant_id, username, password):
         """

--- a/cortex/client.py
+++ b/cortex/client.py
@@ -153,6 +153,9 @@ class Client(object):
     def _mk_connector(self):
         return ServiceConnector(self._url, self._version, self._token.token, self._verify_ssl_cert)
 
+    # expose this to allow developer to pass client instance into Connectors
+    def to_connector(self):
+        return self._mk_connector()
 
 class Local:
 
@@ -221,7 +224,7 @@ class Cortex(object):
         if not password:
             password = env.password
 
-        auth = AuthenticationClient(api_endpoint, version=2)
+        auth = AuthenticationClient(api_endpoint, version=2, verify_ssl_cert=verify_ssl_cert)
         t = _Token(auth, token, account, username, password)
 
         return Client(url=api_endpoint, version=api_version, token=t, verify_ssl_cert=verify_ssl_cert)

--- a/cortex/connection.py
+++ b/cortex/connection.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 
 import json
-from .serviceconnector import ServiceConnector
+from .serviceconnector import _Client, ServiceConnector
 from .camel import CamelResource
 from .utils import get_logger
 from .utils import raise_for_status_with_detail
@@ -24,14 +24,16 @@ from .utils import raise_for_status_with_detail
 log = get_logger(__name__)
 
 
-class ConnectionClient:
+class ConnectionClient(_Client):
     """
     A client used to manage connections.
     """
     URIs = {'connections': 'connections'}
 
-    def __init__(self, url, version, token):
-        self._serviceconnector = ServiceConnector(url, version, token)
+    def __init__(self,  *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Content apis only have v2..
+        self._serviceconnector.version = 2
 
     def save_connection(self, connection: object):
         """

--- a/cortex/content.py
+++ b/cortex/content.py
@@ -23,18 +23,20 @@ from requests.exceptions import HTTPError
 import tenacity
 import time
 
-from .serviceconnector import ServiceConnector
+from .serviceconnector import _Client
 from .utils import raise_for_status_with_detail
 
 
-class ManagedContentClient:
+class ManagedContentClient(_Client):
     """
     A client used to access the Cortex managed content service (blob store).
     """
     URIs = {'content':  'content'}
 
-    def __init__(self, url, version, token):
-        self._serviceconnector = ServiceConnector(url, version, token)
+    def __init__(self,  *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Content apis only have v2..
+        self._serviceconnector.version = 2
 
     def upload(self, key: str, stream_name: str, stream: object, content_type: str, retries: int = 1):
         """Store `stream` file in S3.
@@ -144,7 +146,7 @@ class ManagedContentClient:
         """
         uri = self._make_content_uri(key)
         r = self._serviceconnector.request('HEAD', uri)
-        return r.status_code is 200
+        return r.status_code == 200
 
     ## Private ##
 

--- a/cortex/dataset.py
+++ b/cortex/dataset.py
@@ -26,21 +26,18 @@ from .camel import CamelResource
 from .pipeline import Pipeline
 from .pipeline_loader import PipelineLoader
 from .properties import PropertyManager
-from .serviceconnector import ServiceConnector
+from .serviceconnector import _Client
 from .utils import raise_for_status_with_detail
 
 log = get_logger(__name__)
 
 
-class DatasetsClient:
+class DatasetsClient(_Client):
     """
     A client used to manage datasets.
     """
     URIs = {'datasets': 'datasets',
             'content':  'content'}
-
-    def __init__(self, url, version, token):
-        self._serviceconnector = ServiceConnector(url, version, token)
 
     def list_datasets(self):
         """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ pylint>=2.3.0,<3
 pytest-cov==2.5.1
 pytest>=3.2.5,<4
 mock>=2,<3
+pyjwt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36
+envlist = py36,py38
 
 [testenv]
 commands =


### PR DESCRIPTION
Made *Client classes more consistent:
   Removed __init__ init methods
   Use super()'s __init__
Made __init__ tolerate both args, kwargs, and client object
Make api version have defaults version=3 to make developers lives easier
    with ConnectionClient and ManageContentClient being version=2
Add py38 to tox.ini env list..