### PR TITLE
changing env list for tox testing to use pythonX.Y instead of pyXY

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37,py38,py39
+envlist = python3.7,python3.8,python3.9
 
 [testenv]
 commands =


### PR DESCRIPTION
Build started failing randomly (could've swore it was fine in the new gocd yesterday)
```
============================== 34 passed in 0.50s ==============================
py38 create: /work/.tox/py38
ERROR: InterpreterNotFound: python3.8
py39 create: /work/.tox/py39
ERROR: InterpreterNotFound: python3.9
___________________________________ summary ____________________________________
  py37: commands succeeded
ERROR:  py38: InterpreterNotFound: python3.8
ERROR:  py39: InterpreterNotFound: python3.9
make: *** [Makefile:45: test] Error 1
```


https://stackoverflow.com/a/68413752