### PR TITLE
Update builder image to Python 3.10, and tox tests to use Python 3.8 - 3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ notebooks/**/*.md
 **/.ipynb_checkpoints/
 *BranchRevision.json
 venv/
+*.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10.2-slim
 ENV ISTIO_QUIT_API=http://localhost:15020
 ENV ENVOY_ADMIN_API=http://localhost:15000
-COPY --from=redboxoss/scuttle:latest /scuttle /bin/scuttle
+COPY --from=c12e/scuttle:latest-main /scuttle /bin/scuttle
 COPY . /app
 RUN cd /app\
     && pip install -e .\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,1 @@
-FROM python:3.10.2-slim
-ENV ISTIO_QUIT_API=http://localhost:15020
-ENV ENVOY_ADMIN_API=http://localhost:15000
-COPY --from=c12e/scuttle:latest-main /scuttle /bin/scuttle
-COPY . /app
-RUN cd /app\
-    && pip install -e .\
-    && pip install flask fastapi uvicorn typing\
-    && echo "default:x:1001:0:Default Application User:/app:/sbin/nologin" >> /etc/passwd
-USER default
-WORKDIR /app
-ENTRYPOINT ["scuttle", "python", "/app/main.py"]
+Dockerfile.c12e-ci.cortex-python-lib

--- a/Dockerfile.c12e-ci.cortex-python-lib
+++ b/Dockerfile.c12e-ci.cortex-python-lib
@@ -1,0 +1,12 @@
+FROM python:3.10.2-slim
+ENV ISTIO_QUIT_API=http://localhost:15020
+ENV ENVOY_ADMIN_API=http://localhost:15000
+COPY --from=c12e/scuttle:latest /scuttle /bin/scuttle
+COPY . /app
+RUN cd /app\
+    && pip install -e .\
+    && pip install flask fastapi uvicorn typing\
+    && echo "default:x:1001:0:Default Application User:/app:/sbin/nologin" >> /etc/passwd
+USER default
+WORKDIR /app
+ENTRYPOINT ["scuttle", "python", "/app/main.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DISTRIBUTION_NAME = $(shell python setup.py --name)
 DISTRIBUTION_VERSION = $(shell python setup.py --version)
 
-.PHONY: clean dev.install build build.alpha build.release dev.test test stage docs dev.push
+.PHONY: clean dev.install build build.alpha build.release dev.test test stage dev.push docs.dev docs.multi docs.package
 
 clean:
 	rm -rf ./build

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ To install the optional components:
 
 When developing, it's a best practice to work in a virtual environment. Create and activate a virtual environment:
 ```
-  > virtualenv --python=python3.6 _venv
+  > virtualenv --python=python3.8 _venv
   > source _venv/bin/activate
 ```
 

--- a/c12e-ci.yml
+++ b/c12e-ci.yml
@@ -1,5 +1,5 @@
 builder:
-  image: python:3.7-buster
+  image: python:3.10-bullseye
   command: bash -cx 'apt-get update
     && apt-get install -y jq
     && make dev.install

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = python3.7,python3.8,python3.9
+envlist = python3.8,python3.9,python3.10
 
 [testenv]
 commands =


### PR DESCRIPTION
Overview of changes:
* Updates builder images to python 3.10 from 3.7. The pipelines were failing because of a transitive dependency issue specific to the developer dependencies installed in a Python 3.7 env.  So, using Johan’s changes to upgrade the Python env in the pipelines to 3.10 fixes the documentation build
  - Just for reference, `MarkupSafe` is being installed by sphinx and an incompatible version of `Jinja2` was being installed in the Python 3.7 env (`mitmproxy==5.3.0` -> `flask==1.1.4` -> `jinja2==2.11.3`), see https://github.com/pallets/markupsafe/issues/286. We could alternatively pin `MarkupSafe` to a lower version range to avoid the error, but I think bumping python version is a better option.
* Contains suggested symlink from #102 
* Replaces reference to Python3.6 with Python3.8 in the README (arbitrary choice)
* Include make targets as `PHONY`


