### PR TITLE
Resolve some warnings in building API documentations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ clean:
 	rm -rf ./build
 	rm -rf ./dist
 	rm -rf ./cortex_python.egg-info
+	rm -rf ./cortex-python.docs.tgz
 
 dev.install:
 	pip install -r requirements-dev.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,8 @@ limitations under the License.
 #
 import os
 import sys
+
+# Include cortex/ in the system path
 sys.path.insert(0, os.path.abspath('..'))
 
 
@@ -196,9 +198,12 @@ html_context['display_lower_left'] = True
 
 templates_path = ['_templates']
 
-smv_branch_whitelist = 'master'
+# Regex for branches to build docs
+smv_branch_whitelist = '^(main|staging|develop)$'
+
 # tag format vX.Y.Z
 smv_tag_whitelist = r'^release/\d+\.\d+\.\d+$'
+
 # all tags are considered released
 smv_released_pattern = r'^refs/tags/.*$'
 

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -4,3 +4,7 @@ gitpython==3.1.27
 sphinx-rtd-theme==0.5.2
 sphinxcontrib-restbuilder==0.3
 nbconvert==6.1.0
+
+## This is a dependency from cortex-python (pre-v6.1.0) that was removed, but it must be installed in the environment
+## to build docs for earlier versions of the library.
+pyjwt>=1.6.1,<2


### PR DESCRIPTION
From https://gocd.dci-dev.dev-eks.insights.ai/go/tab/build/detail/cortex-python-pr/9/build/1/build and https://gocd.dci-dev.dev-eks.insights.ai/go/tab/build/detail/cortex-python-develop/19/build/2/build:
```
WARNING: autodoc: failed to import class 'client.Cortex' from module 'cortex'; the following exception was raised:
No module named 'jwt'
WARNING: autodoc: failed to import class 'env.CortexEnv' from module 'cortex'; the following exception was raised:
No module named 'jwt'
WARNING: autodoc: failed to import class 'client.Client' from module 'cortex'; the following exception was raised:
No module named 'jwt'
WARNING: autodoc: failed to import class 'action.Action' from module 'cortex'; the following exception was raised:
No module named 'jwt'
WARNING: autodoc: failed to import class 'agent.Agent' from module 'cortex'; the following exception was raised:
No module named 'jwt'
...
```

The warnings while building the docs were coming from a missing `pyjwt` dependency that was in an older version of the python library - we replaced it with something else. So the fix was to include that as a requirement for the docs.

I can see this dependency requirement being a pain if say we ever have incompatibilities across library versions. We could automate creating a new virtualenv for each branch/version - but that seems bit much (also have figure out how that would work with the `sphinx-multiversion` plugin).


In addition:
* This is building docs for `develop`, `staging`, and `main` branches - our configuration was using `master` but it doesn't exist in the repo
* The current build for `develop` fails because of https://cognitivescale.atlassian.net/browse/FAB-4095. I took a stab that, and left a comment on that issue with the exact failures for when we revisit that issue. 