### PR TITLE
Add a more flexible entrypoint to the python container

### DIFF
--- a/Dockerfile.c12e-ci.cortex-python-lib
+++ b/Dockerfile.c12e-ci.cortex-python-lib
@@ -3,6 +3,7 @@ ENV ISTIO_QUIT_API=http://localhost:15020
 ENV ENVOY_ADMIN_API=http://localhost:15000
 COPY --from=c12e/scuttle:latest /scuttle /bin/scuttle
 COPY ./cortex /tmp/src/cortex
+COPY ./scripts/entrypoint.sh /entrypoint.sh
 COPY setup.py README.md /tmp/src/
 RUN cd /tmp/src\
     && pip install . flask fastapi uvicorn typing\
@@ -10,4 +11,4 @@ RUN cd /tmp/src\
     && rm -r /tmp/src
 USER default
 WORKDIR /app
-ENTRYPOINT ["scuttle", "python", "/app/main.py"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ docs.dev:
 
 # To be removed we don't really support older versions ATM anyway..
 docs.multi:
-	MULTI_VERSION="true" sphinx-multiversion -v docs docs/_build/
+	MULTI_VERSION="false" sphinx-multiversion -v docs docs/_build/
 	cp docs/index.html docs/_build/
 
 docs.package:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eu
+
+function main() {
+    cmd=()
+    if [[ "${SCUTTLE_OFF:-false}" != "true" ]]; then
+      cmd+=("scuttle")
+    fi
+    if [[ $# -eq 0 ]]; then
+      cmd+=("python")
+       cmd+=("/app/main.py")
+    else
+      cmd+=($@)
+    fi
+    echo "${cmd[*]}"
+}
+$(main "$@")


### PR DESCRIPTION
Trying to add a slightly more flexible docker entrypoint 
The default one doesn't play nice with the prediction skill template .. 