### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Three types of checks are configured for this:
 1. [symilar](https://pylint.readthedocs.io/en/v2.16.2/symilar.html) - to test code duplication
 2. [pylint](https://pylint.readthedocs.io/en/v2.16.2/) - for linting
 3. [pytest](https://docs.pytest.org/en/7.2.x/) - for running the unit tests. These are orchestrated through [tox](https://tox.wiki/en/3.27.1/). The tox configuration is available at [`tox.ini`](/tox.ini)
+To install pytest: 
+```
+  > pip install pytest
+```
+א```
+אןאן
 
 There's a convenience `Makefile` that has commands to common tasks, such as build, test, etc. Use it!
 


### PR DESCRIPTION
A small addition by specifing that pytest should be installed by pip before using pytest install.
add pip install pytest