### PR TITLE
Make `cortex-python` a pkgutil style namespace package and bump to 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support for creating Experiments using Model
 
 
-
 ## [6.4.0] - 2023-07-13
 ### Changed
 
 - The top level `cortex` package acts a namespace and no longer exports the `Cortex` or `Message` types.
-  - Change any instances of `from cortex import Cortex` to `from cortex.client import Cortex`
-  - Change any instances of `from cortex import Message` to `from cortex.message import Message`
-  - Change any instances of `from cortex import __version__` to `from cortex.__version__ import __version__`
+  - Update any instances of `from cortex import Cortex` to `from cortex.client import Cortex`
+  - Update any instances of `from cortex import Message` to `from cortex.message import Message`
+  - Update any instances of `from cortex import __version__` to `from cortex.__version__ import __version__`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support for Model CRUD methods
 - Configurable artifact key for loading a Model from an Experiment
 - Support for creating Experiments using Model
+
+
+
+## [6.4.0] - 2023-07-13
+### Changed
+
+- The top level `cortex` package acts a namespace and no longer exports the `Cortex` or `Message` types.
+  - Change any instances of `from cortex import Cortex` to `from cortex.client import Cortex`
+  - Change any instances of `from cortex import Message` to `from cortex.message import Message`
+  - Change any instances of `from cortex import __version__` to `from cortex.__version__ import __version__`

--- a/cortex/__init__.py
+++ b/cortex/__init__.py
@@ -13,12 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from pkgutil import extend_path
 
-from .client import Cortex
-from .message import Message
-
-from .__version__ import __title__, __description__, __url__, __version__
-from .__version__ import __author__, __author_email__, __license__
-from .__version__ import __copyright__
-
-__all__ = ["__version__", "Cortex", "Message"]
+__path__ = extend_path(__path__, __name__)

--- a/cortex/__version__.py
+++ b/cortex/__version__.py
@@ -4,7 +4,7 @@ Metadata for cortex-python
 __title__ = "cortex-python"
 __description__ = "Python module for the CognitiveScale Cortex Cognitive Platform"
 __url__ = "https://github.com/CognitiveScale/cortex-python"
-__version__ = "6.3.1"
+__version__ = "6.4.0"
 __author__ = "CognitiveScale"
 __author_email__ = "support@cognitivescale.com"
 __license__ = "Apache 2.0"

--- a/cortex/client.py
+++ b/cortex/client.py
@@ -73,17 +73,17 @@ class Client:
 
     1. If the user has the Cortex CLI installed and configured to a Fabric environment, AND a default project is set, they can do the following:
 
-    >>> from cortex import Cortex; client = Cortex.client()
+    >>> from cortex.client import Cortex; client = Cortex.client()
 
     2. If the user has the Cortex CLI installed and configured, but a default project is not set:
 
-    >>> from cortex import Cortex; client = Cortex.client(project="some-project")
+    >>> from cortex.client import Cortex; client = Cortex.client(project="some-project")
 
     3. If the user does not have the Cortex CLI installed, or is using the cortex-python package from within a Skill (Daemon) running inside a Fabric cluster, they can simply extract the required parameters from the request object and create a Cortex client like below:
 
     .. code-block::
 
-        from cortex import Cortex
+        from cortex.client import Cortex
 
         @app.post('/invoke')
         def start(req: dict):
@@ -97,7 +97,7 @@ class Client:
     .. code-block:: python
 
         # contents of main.py for a Skill (job)
-        from cortex import Cortex
+        from cortex.client import Cortex
 
         def main(params):
             client = Cortex.from_message(params)
@@ -194,7 +194,7 @@ class Client:
         .. code-block::
 
             ## use default .experiments client helper
-            from cortex import Cortex
+            from cortex.client import Cortex
             client = Cortex.client()
             client.experiments.list_experiments()
             client.experiments.save_experiment()
@@ -232,7 +232,7 @@ class Client:
         .. code-block::
 
             ## use default .connections client helper
-            from cortex import Cortex
+            from cortex.client import Cortex
             client = Cortex.client()
             client.connections.save_connection
             client.connections.get_connection
@@ -268,7 +268,7 @@ class Client:
         .. code-block::
 
             ## use default .content client helper
-            from cortex import Cortex
+            from cortex.client import Cortex
             client = Cortex.client()
             client.content.list
             client.content.upload
@@ -306,7 +306,7 @@ class Client:
         .. code-block::
 
             ## use default .models client helper
-            from cortex import Cortex
+            from cortex.client import Cortex
             client = Cortex.client()
             client.models.list_models()
             client.models.get_model()
@@ -348,7 +348,7 @@ class Client:
         .. code-block::
 
             ## use default .secrets client helper
-            from cortex import Cortex
+            from cortex.client import Cortex
             client = Cortex.client()
             client.models.get_secret()
             client.models.post_secret()
@@ -385,7 +385,7 @@ class Client:
         .. code-block::
 
             ## use default .skills client helper
-            from cortex import Cortex
+            from cortex.client import Cortex
             client = Cortex.client()
             client.skills.get_skill()
             client.skills.save_skill()
@@ -426,7 +426,7 @@ class Client:
         .. code-block::
 
             ## use default .sessions client helper
-            from cortex import Cortex
+            from cortex.client import Cortex
             client = Cortex.client()
             client.sessions.start_session()
             client.sessions.get_session_data()
@@ -465,7 +465,7 @@ class Client:
         .. code-block::
 
             ## use default .types client helper
-            from cortex import Cortex
+            from cortex.client import Cortex
             client = Cortex.client()
             client.types.get_type()
             client.types.save_type()
@@ -545,7 +545,7 @@ class Cortex:
 
         **Example**
 
-        >>> from cortex import Cortex
+        >>> from cortex.client import Cortex
         >>> cortex = Cortex.client(project='example-project')
 
         :param api_endpoint: The Cortex URL.

--- a/cortex/content.py
+++ b/cortex/content.py
@@ -38,7 +38,7 @@ class ManagedContentClient(_Client):
     """
     A client used to access the `Cortex managed content service (blob store) <https://cognitivescale.github.io/cortex-fabric/docs/manage-data/managed-content>`_. You can find a pre-created instance of this class on every :py:class:`cortex.client.Client` instance via the :py:attr:`Client.content` attribute.
 
-    >>> from cortex import Cortex; client = Cortex.client();
+    >>> from cortex.client import Cortex; client = Cortex.client();
     >>> client.content.list() # list content from the default project configured for the user
 
     """  # pylint: disable=line-too-long

--- a/cortex/experiment/remote.py
+++ b/cortex/experiment/remote.py
@@ -41,7 +41,7 @@ class ExperimentClient(_Client):
     """
     A client for the `Cortex experiment and model management API <https://cognitivescale.github.io/cortex-fabric/docs/models/experiments>`_. You can find a pre-created instance of this class on every :class:`cortex.client.Client` instance via the :attr:`Client.experiments` attribute.
 
-    >>> from cortex import Cortex; client = Cortex.client();
+    >>> from cortex.client import Cortex; client = Cortex.client();
     >>> client.experiments.list_experiments() # list experiments from the default project configured for the user
     """  # pylint: disable=line-too-long
 
@@ -67,7 +67,7 @@ class ExperimentClient(_Client):
     def list_experiments(self) -> List[Dict]:
         """Returns a list of experiments available on the project configured for the experiment client.
 
-        >>> from cortex import Cortex; cc=Cortex.client()
+        >>> from cortex.client import Cortex; cc=Cortex.client()
         >>> cc.experiments.list_experiments()
         [{'_version': 2, 'name': 'op-gc_dtree_exp', 'title': 'Decision Tree model', 'description': 'Decision Tree model', 'meta': None, 'tags': [], 'modelId': 'op-german-credit', 'updatedAt': '2023-01-24T10:21:01.347Z', 'createdAt': '2023-01-24T10:11:16.445Z'}]
 
@@ -85,7 +85,7 @@ class ExperimentClient(_Client):
     def save_experiment(self, experiment_name: str, model_id=None, **kwargs) -> Dict:
         """Save an experiment with the provided `experiment_name`, and `modelId`. All the fields specified in the `API reference for Cortex Experiments <https://cognitivescale.github.io/cortex-fabric/swagger/index.html#operation/CreateExperiment>`_ (except name and modelId) can be passed in as keyword args to this method
 
-        >>> from cortex import Cortex; cc=Cortex.client()
+        >>> from cortex.client import Cortex; cc=Cortex.client()
         >>> cc.experiments.save_experiment('exp-name', 'juhf')
         {'_version': 1, 'name': 'exp-name', 'tags': [], '_projectId': 'exp-test', 'modelId': 'juhf'}
 
@@ -116,7 +116,7 @@ class ExperimentClient(_Client):
     def delete_experiment(self, experiment_name: str) -> bool:
         """Delete an experiment specified by `experiment_name`
 
-        >>> from cortex import Cortex; cc=Cortex.client(project='test')
+        >>> from cortex.client import Cortex; cc=Cortex.client(project='test')
         >>> cc.experiments.delete_experiment('another')
         True
 
@@ -137,7 +137,7 @@ class ExperimentClient(_Client):
     def get_experiment(self, experiment_name: str) -> Dict:
         """Retrieve all data for the experiment with name `experiment_name`
 
-        >>> from cortex import Cortex; cc=Cortex.client()
+        >>> from cortex.client import Cortex; cc=Cortex.client()
         >>> cc.experiments.get_experiment('ddgc_dtree_exp')
         {'_version': 1, 'name': 'ddgc_dtree_exp', 'title': 'Decision Tree model', 'description': 'Decision Tree model', 'tags': [], '_projectId': 'test', 'modelId': 'german-credit-model'}
 
@@ -157,7 +157,7 @@ class ExperimentClient(_Client):
     def list_runs(self, experiment_name: str) -> List[Dict]:
         """`List all the runs <https://cognitivescale.github.io/cortex-fabric/swagger/index.html#operation/ListRuns>`_ that belong to the specified `experiment_name`
 
-        >>> from cortex import Cortex; cc=Cortex.client()
+        >>> from cortex.client import Cortex; cc=Cortex.client()
         >>> cc.experiments.list_runs('op-gc_dtree_exp')
         [{'_id': '63cfb10ffe65fb07bf8a94b9', '_projectId': 'test', 'runId': 'run_01', 'experimentName': 'op-gc_dtree_exp', 'params': {'category': 'Decision Tree', 'version': 1, 'SourceData': 'Upstream Server Data'}, 'metrics': {'accuracy': 0.68}, 'meta': {'algo': 'DecisionTreeClassifier'}, '_createdAt': '2023-01-24T10:21:03.120Z', '_updatedAt': '2023-01-24T10:21:04.497Z', 'artifacts': {'model': 'experiments/op-gc_dtree_exp/run_01/artifacts/model'}}]
 
@@ -180,7 +180,7 @@ class ExperimentClient(_Client):
     ) -> List[Dict]:
         """Similar to :meth:`cortex.experiment.ExperimentClient.list_runs`, but also allows you to filter with a mongo-style query dictionary passed in through `filter_obj`, along with `sort` and `limit` options
 
-        >>> from cortex import Cortex; cc=Cortex.client()
+        >>> from cortex.client import Cortex; cc=Cortex.client()
         >>> cc.experiments.find_runs('op-gc_dtree_exp', filter_obj={"runId": "run_01"})
         [{'_id': '63cfb10ffe65fb07bf8a94b9', '_projectId': 'test', 'runId': 'run_01', 'experimentName': 'op-gc_dtree_exp', 'params': {'category': 'Decision Tree', 'version': 1, 'SourceData': 'Upstream Server Data'}, 'metrics': {'accuracy': 0.68}, 'meta': {'algo': 'DecisionTreeClassifier'}, '_createdAt': '2023-01-24T10:21:03.120Z', '_updatedAt': '2023-01-24T10:21:04.497Z', 'artifacts': {'model': 'experiments/op-gc_dtree_exp/run_01/artifacts/model'}}]
 
@@ -219,7 +219,7 @@ class ExperimentClient(_Client):
     ) -> str:
         """Delete runs belonging to the specified `experiment_name` that match the optional `filter_obj` conditions
 
-        >>> from cortex import Cortex; cc=Cortex.client(project='test')
+        >>> from cortex.client import Cortex; cc=Cortex.client(project='test')
         >>> cc.experiments.delete_runs('op-gc_dtree_exp')
         'Runs deleted'
 
@@ -250,7 +250,7 @@ class ExperimentClient(_Client):
     def create_run(self, experiment_name: str, **kwargs) -> Dict:
         """Creates a run for the specified `experiment_name`. Refer to the `official CreateRun docs <https://cognitivescale.github.io/cortex-fabric/swagger/index.html#operation/CreateRun>`_ for information on other possible `kwargs` this method can accept
 
-        >>> from cortex import Cortex; cc=Cortex.client(project='test')
+        >>> from cortex.client import Cortex; cc=Cortex.client(project='test')
         >>> cc.experiments.create_run('op-gc_dtree_exp')
         {'_projectId': 'test', 'runId': 'ox00gu0', 'experimentName': 'op-gc_dtree_exp', '_id': '63f0f9e809c5267ccb9110ca', '_createdAt': '2023-02-18T16:16:40.405Z', '_updatedAt': '2023-02-18T16:16:40.405Z'}
 
@@ -279,7 +279,7 @@ class ExperimentClient(_Client):
     def get_run(self, experiment_name: str, run_id: str) -> Dict:
         """Get all details available for a `run_id` belonging to an `experiment_name`
 
-        >>> from cortex import Cortex; cc=Cortex.client(project='test')
+        >>> from cortex.client import Cortex; cc=Cortex.client(project='test')
         >>> cc.experiments.get_run('op-gc_dtree_exp', 'ox00gu0')
         {'_id': '63f0f9e809c5267ccb9110ca', '_projectId': 'test', 'runId': 'ox00gu0', 'experimentName': 'op-gc_dtree_exp', '_createdAt': '2023-02-18T16:16:40.405Z', '_updatedAt': '2023-02-18T16:16:40.405Z'}
 

--- a/local/proxy_cortex_internal.py
+++ b/local/proxy_cortex_internal.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 
 from mitmproxy import http
-from cortex import Cortex
+from cortex.client import Cortex
 import json
 import re
 import os

--- a/migration.md
+++ b/migration.md
@@ -61,7 +61,7 @@ Cortex magics can be used only when the optional `builders` dependency is instal
 1. The `InputMessage` and `OutputMessage` classes have been deprecated. Instead, use the `Message` class:
 
 ```
-> from cortex import Message
+> from cortex.client import Message
 ```
 
 2. `ModelClient`, `ModelProcess`, and `ModelRouter` have been deprecated. Instead, use the `experiment` API in the `Client`
@@ -77,7 +77,7 @@ you can manage secrets through the Cortex Vault in the Cortex Console or via the
 Instead, use the `Client.message()` method:
 
 ```
-> from cortex import Cortex
+> from cortex.client import Cortex
 
 > cortex = Cortex.client()
 > message = cortex.message(payload={'value': 'hello world'})

--- a/migration.md
+++ b/migration.md
@@ -61,7 +61,7 @@ Cortex magics can be used only when the optional `builders` dependency is instal
 1. The `InputMessage` and `OutputMessage` classes have been deprecated. Instead, use the `Message` class:
 
 ```
-> from cortex.client import Message
+> from cortex.message import Message
 ```
 
 2. `ModelClient`, `ModelProcess`, and `ModelRouter` have been deprecated. Instead, use the `experiment` API in the `Client`

--- a/test/unit/connectionclient_test.py
+++ b/test/unit/connectionclient_test.py
@@ -20,7 +20,7 @@ import requests_mock
 
 from cortex.connection import ConnectionClient
 from cortex.content import ManagedContentClient
-from cortex import Cortex
+from cortex.client import Cortex
 
 from .fixtures import john_doe_token, mock_api_endpoint, mock_project
 

--- a/test/unit/cortex_test.py
+++ b/test/unit/cortex_test.py
@@ -20,7 +20,7 @@ from unittest.mock import Mock
 
 import requests_mock
 
-from cortex import Cortex
+from cortex.client import Cortex
 from cortex.message import Message
 import pytest
 from cortex.connection import ConnectionClient, Connection

--- a/test/unit/experiment_test.py
+++ b/test/unit/experiment_test.py
@@ -20,7 +20,7 @@ import os
 
 import requests_mock
 
-from cortex import Cortex
+from cortex.client import Cortex
 from cortex.experiment import ExperimentClient, Experiment
 
 from .fixtures import mock_api_endpoint, mock_project

--- a/test/unit/run_test.py
+++ b/test/unit/run_test.py
@@ -22,7 +22,7 @@ import requests_mock
 from pytest import raises
 from requests.exceptions import HTTPError
 
-from cortex import Cortex
+from cortex.client import Cortex
 from cortex.experiment import ExperimentClient, RemoteRun, Experiment
 from .fixtures import build_mock_url, mock_api_endpoint, mock_project, john_doe_token
 

--- a/test/unit/serviceconnector_test.py
+++ b/test/unit/serviceconnector_test.py
@@ -18,7 +18,7 @@ import json
 import requests
 import requests_mock
 
-from cortex import __version__
+from cortex.__version__ import __version__
 from cortex.serviceconnector import ServiceConnector
 
 from .fixtures import mock_api_endpoint, john_doe_token

--- a/test/unit/sessionclient_test.py
+++ b/test/unit/sessionclient_test.py
@@ -19,7 +19,7 @@ import uuid
 import requests_mock
 
 from cortex.session import SessionClient
-from cortex import Cortex
+from cortex.client import Cortex
 
 from .fixtures import john_doe_token, mock_api_endpoint, mock_project
 


### PR DESCRIPTION
Related Issue: https://cognitivescale.atlassian.net/browse/FAB-5951
Related PR: https://github.com/CognitiveScale/cortex-profiles-sdk/pull/50


The existing imports that will break are:

```python
from cortex import Cortex
from cortex import Message
from cortex import __version__
```

And should be changed to:

```python
from cortex.client import Cortex
from cortex.message import Message
from cortex.__version__ import __version__
```
