### PR TITLE
Pass ALPHA_BUILD variable to c12e-ci container

### DIFF
--- a/c12e-ci.yml
+++ b/c12e-ci.yml
@@ -1,4 +1,6 @@
 builder:
+  environment:
+    ALPHA_BUILD: "${ALPHA_BUILD}"
   image: python:3.11-bullseye
   command: bash -cx 'apt-get update
     && apt-get install -y jq


### PR DESCRIPTION
The variable wasn't being passed to the container, so the `Makefile` defaulted to always doing a non-alpha (regular) build, this caused the accidental publishing of `6.4.0` on PyPi :/

This will need to be merged up to from `develop` to `staging` to publish the correct alpha version.