### PR TITLE
FAB-6068 adding param to utils.generate_token

### DIFF
--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -156,6 +156,10 @@ def generate_token(config, verify_ssl_cert: Union[bool, str]=True, validity=2):
     """
     Use the Personal Access Token (JWK) obtained from Cortex's console
     to generate JWTs to access cortex services..
+    
+    :param verify_ssl_cert: (optional) Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a string, in which case it must be a path
+            to a CA bundle to use. Defaults to ``True``.
     """
     try:
         server_ts = int(

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -22,13 +22,13 @@ import urllib.parse
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Union
 
 import python_jwt as py_jwt
 import jwcrypto.jwk as jwkLib
 from requests.exceptions import HTTPError
 from requests import request
 from .exceptions import BadTokenException, AuthenticationHeaderError
-from typing import Union
 
 
 def md5sum(file_name, blocksize=65536):

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -141,24 +141,24 @@ def verify_JWT(token, config=None):
         return generate_token(config)
 
 
-def _get_fabric_info(config: dict):
+def _get_fabric_info(config: dict, verify_ssl_cert: bool=True):
     uri = config.get("url") + "/fabric/v4/info"
     headers = {"Content-Type": "application/json"}
-    return request("GET", uri, headers=headers).json()
+    return request("GET", uri, headers=headers, verify=verify_ssl_cert,).json()
 
 
-def _get_fabric_server_ts(config: dict):
-    return _get_fabric_info(config).get("serverTs")
+def _get_fabric_server_ts(config: dict, verify_ssl_cert: bool=True):
+    return _get_fabric_info(config, verify_ssl_cert).get("serverTs")
 
 
-def generate_token(config, validity=2):
+def generate_token(config, verify_ssl_cert: bool=True, validity=2):
     """
     Use the Personal Access Token (JWK) obtained from Cortex's console
     to generate JWTs to access cortex services..
     """
     try:
         server_ts = int(
-            _get_fabric_server_ts(config) / 1000
+            _get_fabric_server_ts(config, verify_ssl_cert) / 1000
         )  # fabric info returns serverTs in milliseconds
         key = jwkLib.JWK.from_json(json.dumps(config.get("jwk")))
         token_payload = {

--- a/cortex/utils.py
+++ b/cortex/utils.py
@@ -28,6 +28,7 @@ import jwcrypto.jwk as jwkLib
 from requests.exceptions import HTTPError
 from requests import request
 from .exceptions import BadTokenException, AuthenticationHeaderError
+from typing import Union
 
 
 def md5sum(file_name, blocksize=65536):
@@ -141,17 +142,17 @@ def verify_JWT(token, config=None):
         return generate_token(config)
 
 
-def _get_fabric_info(config: dict, verify_ssl_cert: bool=True):
+def _get_fabric_info(config: dict, verify_ssl_cert: Union[bool, str]=True):
     uri = config.get("url") + "/fabric/v4/info"
     headers = {"Content-Type": "application/json"}
     return request("GET", uri, headers=headers, verify=verify_ssl_cert,).json()
 
 
-def _get_fabric_server_ts(config: dict, verify_ssl_cert: bool=True):
+def _get_fabric_server_ts(config: dict, verify_ssl_cert: Union[bool, str]=True):
     return _get_fabric_info(config, verify_ssl_cert).get("serverTs")
 
 
-def generate_token(config, verify_ssl_cert: bool=True, validity=2):
+def generate_token(config, verify_ssl_cert: Union[bool, str]=True, validity=2):
     """
     Use the Personal Access Token (JWK) obtained from Cortex's console
     to generate JWTs to access cortex services..


### PR DESCRIPTION
can't use (cortex)client here, leads to a circular import, introduced a default param ( `verify_ssl_cert` )for the utils.generate_token, this generate_token is then used by the client internally (as a util function), for now Using this as shown below is working fine, 
```
>>> from cortex.utils import generate_token, get_cortex_profile
>>> generate_token(get_cortex_profile("cpo1"))
>>> generate_token(get_cortex_profile("cpo1"), verify_ssl_cert=False)
>>> generate_token(get_cortex_profile("cpo1"), verify_ssl_cert="<path_to>/ca.crt")
```
but I believe having a method as part of the client itself that generates_token based on the client params something like:
```
>>> from cortex.client import Cortex
>>> client = Cortex.client(api_endpoint="XXXX", verify_ssl_cert=True, token="XXXX, project="XXXX")
>>> client.generate_token()
```
make sense long term?
